### PR TITLE
Small hyperlink fix

### DIFF
--- a/app/src/footer.js
+++ b/app/src/footer.js
@@ -18,7 +18,7 @@ class Footer extends Component {
                                 </a>
                             </li>
                             <li>
-                                <a href="https://blog.battlecode.org/terms">
+                                <a href="https://battlecode.org/terms">
                                     Usage Terms
                                 </a>
                             </li>


### PR DESCRIPTION
blog.battlecode.org/terms ->battlecode.org/terms 

Neither of these work though :(