### PR TITLE
Fix bug where game result is incorrect if last castle is last unit

### DIFF
--- a/coldbrew/game.js
+++ b/coldbrew/game.js
@@ -527,6 +527,9 @@ Game.prototype.isOver = function() {
         }
     }
 
+    if (total[0] === 0) nulls[0] = -1;
+    if (total[1] === 0) nulls[1] = -1;
+
     if (nulls[0] === total[0] && nulls[1] === total[1]) {
         this.winner = +(Math.random() > 0.5);
         this.win_condition = 4;


### PR DESCRIPTION
There is a small bug in the current version of BC where the game result is incorrectly reported as "failed to initialize" if the losing team has 0 units at the end of the game. This fixes that bug.