### PR TITLE
ensure there are enough sprites

### DIFF
--- a/app/src/views/visualizer.js
+++ b/app/src/views/visualizer.js
@@ -223,16 +223,8 @@ class Visualizer {
         // Create large pools of sprites from which to draw
         this.sprite_pools = new Array(6);
         for (let i = 0; i < 6; i++) this.sprite_pools[i] = [];
-        for (let i = 0; i < 6; i++) { // Castles
-            var sprite = new PIXI.Sprite(this.textures[0]);
-            sprite.anchor = new PIXI.Point(0.5, 0.5);
-            sprite.visible = false;
-            sprite.mask = this.grid_mask;
-            this.spritestage.addChild(sprite);
-            this.sprite_pools[0].push(sprite);
-        }
-        for (let i = 1; i < 6; i++) for (let j = 0; j < 1000; j++) { // Other
-            sprite = new PIXI.Sprite(this.textures[i]);
+        for (let i = 0; i < 6; i++) for (let j = 0; j < 4096; j++) {
+            var sprite = new PIXI.Sprite(this.textures[i]);
             sprite.anchor = new PIXI.Point(0.5, 0.5);
             sprite.visible = false;
             sprite.mask = this.grid_mask;
@@ -250,17 +242,8 @@ class Visualizer {
         // Create large pools of strategic sprites from which to draw
         this.strategic_sprite_pools = new Array(6);
         for (let i = 0; i < 6; i++) this.strategic_sprite_pools[i] = [];
-        for (let i = 0; i < 6; i++) { // Castles
-            var sprite = new PIXI.Sprite(this.strategic_textures[0]);
-            sprite.anchor = new PIXI.Point(0.5, 0.5);
-            sprite.mask = this.grid_mask;
-            sprite.visible = false;
-            this.spritestage.addChild(sprite);
-            this.strategic_sprite_pools[0].push(sprite);
-        }
-        
-        for (let i = 1; i < 6; i++) for (let j = 0; j < 1000; j++) { // Other
-            sprite = new PIXI.Sprite(this.textures[i]);
+        for (let i = 0; i < 6; i++) for (let j = 0; j < 4096; j++) {
+            var sprite = new PIXI.Sprite(this.textures[i]);
             sprite.anchor = new PIXI.Point(0.5, 0.5);
             sprite.mask = this.grid_mask;
             sprite.visible = false;


### PR DESCRIPTION
visualizer crashes when there are a lot of units (eg mass spawn pilgrims)