### PR TITLE
Ensure attacks actually cost fuel

### DIFF
--- a/coldbrew/action_record.js
+++ b/coldbrew/action_record.js
@@ -283,6 +283,8 @@ ActionRecord.prototype.enactMove = function() {
 }
 
 ActionRecord.prototype.enactAttack = function() {
+    this.game.fuel[this.robot.team] -= SPECS.UNITS[this.robot.unit]['ATTACK_FUEL_COST'];
+
     // Handle AOE damage
     for (var r=0; r<this.game.shadow.length; r++) {
         for (var c=0; c<this.game.shadow[0].length; c++) {


### PR DESCRIPTION
Military intervention always comes at a cost

**For clarity:** It seems that the code up until now just checks if the team has enough fuel to enact the attack, but does not actually withdraw the fuel cost of the attack when it is executed.

This should fix it.