### PR TITLE
Fixed updating signal fuel costs in starter kits

### DIFF
--- a/coldbrew/starter/java_starter.js
+++ b/coldbrew/starter/java_starter.js
@@ -119,7 +119,8 @@ public class BCAbstractRobot {
     }
 
     public void signal(int value, int radius) {
-        if (fuel < Math.ceil(Math.sqrt(radius))) throw new BCException("Not enough fuel to signal given radius.");
+        int fuelNeeded = (int) Math.ceil(Math.sqrt(radius));
+        if (fuel < fuelNeeded) throw new BCException("Not enough fuel to signal given radius.");
 
         if (value < 0 || value >= Math.pow(2, SPECS.COMMUNICATION_BITS)) throw new BCException("Invalid signal, must be within bit range.");
         if (radius > 2*Math.pow(SPECS.MAX_BOARD_SIZE-1,2)) throw new BCException("Signal radius is too big.");
@@ -127,7 +128,7 @@ public class BCAbstractRobot {
         signal = value;
         signalRadius = radius;
 
-        fuel -= radius;
+        fuel -= fuelNeeded;
     }
 
     public void castleTalk(int value) {

--- a/coldbrew/starter/js_starter.js
+++ b/coldbrew/starter/js_starter.js
@@ -96,15 +96,16 @@ export class BCAbstractRobot {
     // Set signal value.
     signal(value, radius) {
         // Check if enough fuel to signal, and that valid value.
-
-        if (this.fuel < Math.ceil(Math.sqrt(radius))) throw "Not enough fuel to signal given radius.";
+        
+        var fuelNeeded = Math.ceil(Math.sqrt(radius));
+        if (this.fuel < fuelNeeded) throw "Not enough fuel to signal given radius.";
         if (!Number.isInteger(value) || value < 0 || value >= Math.pow(2,SPECS.COMMUNICATION_BITS)) throw "Invalid signal, must be int within bit range.";
         if (radius > 2*Math.pow(SPECS.MAX_BOARD_SIZE-1,2)) throw "Signal radius is too big.";
 
         this._bc_signal = value;
         this._bc_signal_radius = radius;
 
-        this.fuel -= radius;
+        this.fuel -= fuelNeeded;
     }
 
     // Set castle talk value.

--- a/coldbrew/starter/python_starter.js
+++ b/coldbrew/starter/python_starter.js
@@ -87,7 +87,8 @@ class BCAbstractRobot:
 
     def signal(self, value, radius):
         # Check if enough fuel to signal, and that valid value.
-        if self.fuel < math.ceil(math.sqrt(radius)):
+        fuelNeeded = int(math.ceil(math.sqrt(radius)))
+        if self.fuel < fuelNeeded:
             raise Exception("Not enough fuel to signal given radius.")
         
         if value < 0 or value >= 2**SPECS['COMMUNICATION_BITS']:
@@ -99,7 +100,7 @@ class BCAbstractRobot:
         self._bc_signal = value
         self._bc_signal_radius = radius
 
-        self.fuel -= radius
+        self.fuel -= fuelNeeded
 
     def castle_talk(self, value):
         if value < 0 or value >= 2**SPECS['CASTLE_TALK_BITS']:


### PR DESCRIPTION
Currently, fuel costs are not subtracted correctly according to 0.4.0 spec changes. Fuel was subtracted r^2 instead of r. This pull request fixes that.