### PR TITLE
Fix infinite loop bug in mapgen

### DIFF
--- a/coldbrew/game.js
+++ b/coldbrew/game.js
@@ -179,7 +179,7 @@ Game.prototype.makeMap = function() {
         var coord = roll_castle();
         
         // forgive me christ
-        while (!passmap[coord[1]][coord[0]] || (castles.length > 0 && Math.min.apply(null, castles.map(c => Math.abs(c[0]-coord[0]) + Math.abs(c[1]-coord[1]))) < 16) && counter < 1000) {
+        while ((!passmap[coord[1]][coord[0]] || (castles.length > 0 && Math.min.apply(null, castles.map(c => Math.abs(c[0]-coord[0]) + Math.abs(c[1]-coord[1]))) < 16)) && counter < 1000) {
             coord = roll_castle();
             counter += 1;
         }
@@ -198,7 +198,7 @@ Game.prototype.makeMap = function() {
         var coord = roll_resource_seed();
 
         // oops i did it again
-        while (!passmap[coord[1]][coord[0]] || Math.min.apply(null, resources_cluster_seeds.map(c => Math.abs(c[0]-coord[0]) + Math.abs(c[1]-coord[1]))) < 12 && counter < 1000) {
+        while ((!passmap[coord[1]][coord[0]] || Math.min.apply(null, resources_cluster_seeds.map(c => Math.abs(c[0]-coord[0]) + Math.abs(c[1]-coord[1]))) < 12) && counter < 1000) {
             coord = roll_resource_seed();
             counter += 1;
         }


### PR DESCRIPTION
Before, if the passmap generated with the automata method was completely (or nearly completely) impassable, the [conditional in the while loop on line 182](https://github.com/battlecode/battlecode19/blob/38ab5ed4571206877c3d274b664c14d124926da3/coldbrew/game.js#L182) cause an infinite loop, since `&&` has higher precedence than `||` in JavaScript, and the `counter < 1000` would effectively only work on the second condition. That is, an infinite loop is still possible if `!passmap[coord[1]][coord[0]]` is always true. By adding parentheses in the proper positions, in the event of a completely full passmap, this loop will now properly short circuit without generating any castles.

Ideally, there would be a check to see if the counter limit activated after these for loops, but as it turns out, if this is the case, then the map has more than one passable region, and the check at the end of the map generation will activate, causing it to create an entirely new map anyways.

As a concrete example, the seed `19450605` would trigger this bug with the old code, but does not with this fix in place. With the fix, I tested ~10,000 random seeds and none of them caused infinite loops in the map generation, whereas before the fix I usually saw it once every ~2,000 seeds or so.