### PR TITLE
Fix mismatched unit IDs between logs and replay

### DIFF
--- a/coldbrew/game.js
+++ b/coldbrew/game.js
@@ -715,7 +715,7 @@ Game.prototype.getGameStateDump = function(robot) {
 
     // Shuffle visible_robots in place
     for (var i = visible_robots.length - 1; i > 0; i--) {
-        var j = Math.floor(this.random() * (i + 1));
+        var j = Math.floor(Math.random() * (i + 1));
         var x = visible_robots[i];
         visible_robots[i] = visible_robots[j];
         visible_robots[j] = x;


### PR DESCRIPTION
Essentially reverts #69 and commit 6a1b946476dfa41f1c54d9dc88d30213892e4bc9

Each call to `this.random` here will modify the internal state of the Mersenne Twister, but the viewer is unable to cheaply determine the number of state changes that occurred. The random number generator in the viewer would therefore end up many states behind, generating incorrect unit IDs for all new units.

Replacing `this.random` with `Math.random` fixes this; while this will have a cost as games will be slightly more nondeterministic, this is probably preferred over having mismatched unit IDs.